### PR TITLE
Prevent floating-point rounding errors in grade calculation (closes #44)

### DIFF
--- a/src/utils/Program.js
+++ b/src/utils/Program.js
@@ -409,14 +409,31 @@ export class Course {
             this.grade = '';
             return;
         }
+        const {scaledScore, scaledScoreTable} = this.expandIntervals();
+        
         for (let i = 0; i < this.gradeTable.length; i++) {
-            if (this.score >= this.scoreTable[i]) {
+            if (scaledScore >= scaledScoreTable[i]) {
                 this.grade = this.gradeTable[i];
                 return;
             }
         }
         this.grade = this.gradeTable[this.gradeTable.length - 1];
     }
+
+    calcScale() {
+    const maxFractionDigits = 5;
+    const [, frac = ''] = String(this.score).split('.');
+    return frac.length > 0 ? 10 ** Math.min(frac.length, maxFractionDigits): 1;
+    }
+
+    expandIntervals() {
+        const scale = this.calcScale();
+        const scaledScore = Math.floor(this.score * scale);
+        const scaledScoreTable = this.scoreTable.map(s =>Math.floor(s * scale));
+        return {scaledScore, scaledScoreTable}
+    }
+
+
 
     calcMultiplier() {
         for (let i = 0; i < this.gradeTable.length; i++) {


### PR DESCRIPTION
### Background
The existing grading logic can incorrectly promote scores to the next higher grade boundary when the score has a fractional part (e.g. `89.5` being treated as `90.0`), due to floating-point imprecision. This leads to inaccurate grade assignments.

### What This Does
- Adds `calcScale()` to compute a scale factor based on the number of decimal digits in the score (capped at 5 digits).  
- Scales both the runtime score and each threshold, then applies `Math.floor` to convert them to integers and ensure consistent comparisons.  
- Keeps the inactive-student check at the top of `calcGrade()` to short-circuit processing for inactive students. 

@beyenilmez 